### PR TITLE
Fix APOC error

### DIFF
--- a/gpohound/utils/bloodhound.py
+++ b/gpohound/utils/bloodhound.py
@@ -1,6 +1,6 @@
 import logging
 from neo4j import GraphDatabase
-from neo4j.exceptions import ServiceUnavailable, AuthError
+from neo4j.exceptions import ServiceUnavailable, AuthError, CypherSyntaxError
 
 logging.getLogger("neo4j").setLevel(logging.INFO)
 
@@ -16,11 +16,13 @@ class BloodHoundConnector:
         self.password = password
         self.driver = None
         self.connection = bool(self.query("RETURN 1"))
+        self.apoc = None
 
         if self.connection:
-            self.apoc = bool(self.query("RETURN apoc.version()"))
-        else:
-            self.apoc = None
+            try:
+                self.apoc = bool(self.query("RETURN apoc.version()"))
+            except CypherSyntaxError as error:
+                logging.debug("Unable to use the APOC plugin : %s", error)
 
     def query(self, query_str, params=None):
         """


### PR DESCRIPTION
This fix resolves an error that occurred when APOC is not installed and the command used does not require it.