### PR TITLE
sAMAccountName hijacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ gpohound analysis --enrich
 
 - Detection of renamed built-in privileged local groups.
 
-- Detection of trustees added to privileged local groups using system-defined variables (e.g., %ComputerName%, %DomainName%) for possible `sAMAccountName` spoofing
+- Detection of trustees added to privileged local groups using "Preference Process Variables" (e.g., %ComputerName%, %DomainName%)
+
+- Detection of abusable trustees using `sAMAccountName` hijacking
 
 - Detection of any trustees added to privileged local groups:
 

--- a/gpohound/analyser.py
+++ b/gpohound/analyser.py
@@ -13,11 +13,11 @@ class GPOAnalyser:
     """Analyse GPOs"""
 
     def __init__(self, ad_utils):
-        self.group_analyser = GroupAnalyser()
+        self.group_analyser = GroupAnalyser(ad_utils)
         self.registry_analyser = RegistryAnalyser()
         self.privilege_rights_analyser = PrivilegeRightsAnalyser(ad_utils)
 
-    def analyse(self, gpo_settings, proccessed_gpo, objects):
+    def analyse(self, domain_sid, gpo_guid, gpo_settings, proccessed_gpo, objects):
         """
         Try to find interesting settings in GPO settings:
             - Sensitive group
@@ -31,7 +31,7 @@ class GPOAnalyser:
         if proccessed_gpo:
 
             if not objects or "group" in objects:
-                group_output = self.group_analyser.analyse(proccessed_gpo)
+                group_output = self.group_analyser.analyse(domain_sid, gpo_guid, proccessed_gpo)
                 if group_output:
                     output["Groups"] = group_output
 

--- a/gpohound/core.py
+++ b/gpohound/core.py
@@ -258,7 +258,9 @@ class GPOHoundCore:
                                         )
 
                                     elif proccessed_gpo:
-                                        analysis = self.gpo_analyser.analyse(gpo_settings, proccessed_gpo, objects)
+                                        analysis = self.gpo_analyser.analyse(
+                                            domain_sid, gpo_guid, gpo_settings, proccessed_gpo, objects
+                                        )
 
                                         if analysis:
                                             output_analysis.setdefault(domain, {}).setdefault(gpo_guid, {}).update(
@@ -287,7 +289,9 @@ class GPOHoundCore:
                         output_proccessed.setdefault(domain, {}).setdefault(gpo_guid, {}).update(proccessed_gpo)
 
                     else:
-                        analysis = self.gpo_analyser.analyse(gpo_settings, proccessed_gpo, objects)
+                        analysis = self.gpo_analyser.analyse(
+                            domain_sid, gpo_guid, gpo_settings, proccessed_gpo, objects
+                        )
 
                         if analysis:
 
@@ -403,7 +407,9 @@ class GPOHoundCore:
                             if proccessed_gpo:
 
                                 # Analyse GPOs
-                                analysis = self.gpo_analyser.analyse(gpo_settings, proccessed_gpo, objects)
+                                analysis = self.gpo_analyser.analyse(
+                                    domain_sid, gpo_guid, gpo_settings, proccessed_gpo, objects
+                                )
 
                                 if analysis:
 

--- a/gpohound/parsers/csv_files.py
+++ b/gpohound/parsers/csv_files.py
@@ -25,7 +25,7 @@ class CSVParser:
                     next(reader)
                 except StopIteration:
                     logging.debug("Unable to parse CSV file : %s", file_path)
-                    return {"audit.csv": None }
+                    return {"audit.csv": None}
 
                 # Filter column that are not in the config
                 for line in reader:

--- a/gpohound/utils/utils.py
+++ b/gpohound/utils/utils.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 from importlib import resources
+from itertools import zip_longest
 
 import yaml
 
@@ -461,6 +462,20 @@ def print_analysed(analysed):
                         # Add values
                         if group.get("Members"):
                             table_group.add_row("Members", table_members)
+
+                        # Add values
+                        if group.get("Hijackable"):
+                            table_hijack = Table(show_lines=True, expand=True)
+                            table_hijack.add_column("20 chars or less", ratio=10, justify="center")
+                            table_hijack.add_column("More than 20 chars", ratio=8, justify="center")
+
+                            hijackable_list = list(
+                                zip_longest(group["Hijackable"]["lte_20"], group["Hijackable"]["gt_20"])
+                            )
+                            for row in hijackable_list:
+                                table_hijack.add_row(row[0], row[1])
+                            table_group.add_row("Hijackable", table_hijack)
+
                         table_group.add_row("References", group.get("references"))
 
                         node.add(table_group)


### PR DESCRIPTION
# sAMAccountName Hijacking

This PR adds detection capabilities for `sAMAccountName` hijacking in GPOs managing user group memberships. It also updates the default trustee search to use  `sAMAccountName` instead of `displayName`.

For more details, check out the article here: https://www.cogiceo.com/en/whitepaper_gpphijacking/