### PR TITLE
Add support of .aas and cap.inf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Default privileged trustees, as well as service accounts with SIDs starting with
 ### SYSVOL and LDAP
 
 - [x] [\[MS-GPAC\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPAC/) Audit Configuration Extension
-- [ ] [\[MS-GPCAP\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPCAP/) Central Access Policies Protocol Extension
+- [X] [\[MS-GPCAP\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPCAP/) Central Access Policies Protocol Extension
 - [x] [\[MS-GPEF\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPEF/) Encrypting File System Extension
 - [x] [\[MS-GPFAS\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPFAS/) Firewall and Advanced Security Data Structure
 - [ ] [\[MS-GPIE\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPIE/) Internet Explorer Maintenance Extension
@@ -209,10 +209,10 @@ Default privileged trustees, as well as service accounts with SIDs starting with
 - [x] [\[MS-GPREG\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPREG/) Registry Extension Encoding
 - [x] [\[MS-GPSB\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPSB/) Security Protocol Extension
 - [x] [\[MS-GPSCR\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPSCR/) Scripts Extension Encoding
-- [ ] [\[MS-GPSI\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPSI/) Software Installation Protocol Extension
+- [X] [\[MS-GPSI\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPSI/) Software Installation Protocol Extension
 
 
-## LDAP Only
+### LDAP Only
 
 - [\[MS-GPDPC\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPDPC/) Deployed Printer Connections Extension
 - [\[MS-GPFR\]](https://learn.microsoft.com/en-us/openspecs/windows_protocols/MS-GPFR/) Folder Redirection Protocol Extension

--- a/config/gpo_files.yaml
+++ b/config/gpo_files.yaml
@@ -1,27 +1,29 @@
-gpt: GPT.ini
-gptemplate: GptTmpl.inf
-scripts : scripts.ini
-psscripts : PSscripts.ini
-eventscripts: gposcripts
-groups: Groups.xml
-registry.pol: registry.pol
-audit: audit.csv
-datasources: DataSources.xml
-devices: Devices.xml
-drives: Drives.xml
-env: EnvironmentVariables.xml
-files: Files.xml
-folderoptions: FolderOptions.xml
-folders: Folders.xml
-inifiles: IniFiles.xml
-internetsettings: InternetSettings.xml
-networkoptions: NetworkOptions.xml
-networkshares: NetworkShares.xml
-poweroptions: PowerOptions.xml
-printers: Printers.xml
-regional: RegionalOptions.xml
-registry: Registry.xml
-scheduledtasks: ScheduledTasks.xml
-services: Services.xml
-shortcuts: Shortcuts.xml
-startmenu: StartMenuTaskbar.xml
+gpt: "GPT.ini"
+gptemplate: "GptTmpl.inf"
+scripts : "scripts.ini"
+psscripts : "PSscripts.ini"
+eventscripts: "gposcripts"
+groups: "Groups.xml"
+registry.pol: "registry.pol"
+audit: "audit.csv"
+datasources: "DataSources.xml"
+devices: "Devices.xml"
+drives: "Drives.xml"
+env: "EnvironmentVariables.xml"
+files: "Files.xml"
+folderoptions: "FolderOptions.xml"
+folders: "Folders.xml"
+inifiles: "IniFiles.xml"
+internetsettings: "InternetSettings.xml"
+networkoptions: "NetworkOptions.xml"
+networkshares: "NetworkShares.xml"
+poweroptions: "PowerOptions.xml"
+printers: "Printers.xml"
+regional: "RegionalOptions.xml"
+registry: "Registry.xml"
+scheduledtasks: "ScheduledTasks.xml"
+services: "Services.xml"
+shortcuts: "Shortcuts.xml"
+startmenu: "StartMenuTaskbar.xml"
+cap: "cap.inf"
+aas: "{GUID}.aas"

--- a/config/gpo_files_structure/aas/aas.yaml
+++ b/config/gpo_files_structure/aas/aas.yaml
@@ -1,0 +1,7 @@
+aas:
+  include:
+  attributes:
+    - Product Key
+    - Product Name
+    - Launch Path
+    - Package Name

--- a/config/gpo_files_structure/inf/cap.yaml
+++ b/config/gpo_files_structure/inf/cap.yaml
@@ -1,0 +1,9 @@
+cap:
+  Version:
+    type : key-value
+    include:
+    attributes:
+      - Signature
+  CAPS:
+    type : string-list
+    include:

--- a/config/gpo_files_structure/inf/gpttmpl.yaml
+++ b/config/gpo_files_structure/inf/gpttmpl.yaml
@@ -1,156 +1,157 @@
-Unicode:
-  type : key-value
-  include:
-  attributes:
-    - Unicode
-Version:
-  type : key-value
-  include:
-  attributes:
-    - signature
-    - Revision
-System Access:
-  type : key-value
-  include:
-  attributes:
-    - MinimumPasswordAge
-    - MaximumPasswordAge
-    - MinimumPasswordLength
-    - PasswordComplexity
-    - PasswordHistorySize
-    - ClearTextPassword
-    - RequireLogonToChangePassword
-    - LockoutBadCount
-    - ResetLockoutCount
-    - LockoutDuration
-    - ForceLogoffWhenHourExpire
-    - LSAAnonymousNameLookup 
-    - EnableAdminAccount 
-    - EnableGuestAccount 
-    - NewAdministratorName
-    - NewGuestName
-Kerberos Policy:
-  type : key-value
-  include:
-  attributes:
-  - MaxTicketAge
-  - MaxRenewAge
-  - MaxServiceAge
-  - MaxClockSkew
-  - TicketValidateClient
-System Log:
-  type : key-value
-  include:
-  attributes:
-  - MaximumLogSize
-  - AuditLogRetentionPeriod
-  - RetentionDays
-  - RestrictGuestAccess
-Security Log:
-  type : key-value
-  include:
-  attributes:
-  - MaximumLogSize
-  - AuditLogRetentionPeriod
-  - RetentionDays
-  - RestrictGuestAccess
-Application Log:
-  type : key-value
-  include:
-  attributes:
-  - MaximumLogSize
-  - AuditLogRetentionPeriod
-  - RetentionDays
-  - RestrictGuestAccess
-Event Audit:
-  type : key-value
-  include:
-  attributes:
-  - AuditSystemEvents
-  - AuditLogonEvents
-  - AuditPrivilegeUse
-  - AuditPolicyChange
-  - AuditAccountManage
-  - AuditProcessTracking
-  - AuditDSAccess
-  - AuditObjectAccess
-  - AuditAccountLogon
-Registry Values:
-  type : key-value
-  include:
-  attributes:
-    - Hive
-    - Type
-    - Data
-Privilege Rights:
-  type : key-value
-  include:
-  attributes:
-  - SeNetworkLogonRight
-  - SeTcbPrivilege
-  - SeMachineAccountPrivilege
-  - SeIncreaseQuotaPrivilege
-  - SeRemoteInteractiveLogonRight
-  - SeBackupPrivilege
-  - SeChangeNotifyPrivilege
-  - SeCreatePagefilePrivilege
-  - SeSystemtimePrivilege
-  - SeCreateTokenPrivilege
-  - SeCreateGlobalPrivilege
-  - SeCreatePermanentPrivilege
-  - SeDebugPrivilege
-  - SeDenyNetworkLogonRight
-  - SeDenyBatchLogonRight
-  - SeDenyServiceLogonRight
-  - SeDenyInteractiveLogonRight
-  - SeDenyRemoteInteractiveLogonRight
-  - SeEnableDelegationPrivilege
-  - SeRemoteShutdownPrivilege
-  - SeAuditPrivilege
-  - SeImpersonatePrivilege
-  - SeIncreaseBasePriorityPrivilege
-  - SeLoadDriverPrivilege
-  - SeLockMemoryPrivilege
-  - SeBatchLogonRight
-  - SeServiceLogonRight
-  - SeInteractiveLogonRight
-  - SeSecurityPrivilege
-  - SeSystemEnvironmentPrivilege
-  - SeManageVolumePrivilege
-  - SeProfileSingleProcessPrivilege
-  - SeSystemProfilePrivilege
-  - SeUndockPrivilege
-  - SeAssignPrimaryTokenPrivilege
-  - SeRestorePrivilege
-  - SeShutdownPrivilege
-  - SeSyncAgentPrivilege
-  - SeTakeOwnershipPrivilege
-  - SeTrustedCredManAccessPrivilege
-  - SeTimeZonePrivilege
-  - SeCreateSymbolicLinkPrivilege
-  - SeIncreaseWorkingSetPrivilege
-  - SeRelabelPrivilege
-Registry Keys:
-  type : comma-separated
-  include:
-  attributes:
-    - PermPropagationMode
-    - AclString
-Service General Setting:
-  type : comma-separated
-  include:
-  attributes:
-    - AclString
-    - StartupMode
-File Security:
-  type : comma-separated
-  include:
-  attributes:
-    - PermPropagationMode
-    - AclString
-Group Membership:
-  type : key-value
-  include:
-  attributes:
-    - Members
-    - Memberof
+gpttmpl:
+  Unicode:
+    type : key-value
+    include:
+    attributes:
+      - Unicode
+  Version:
+    type : key-value
+    include:
+    attributes:
+      - signature
+      - Revision
+  System Access:
+    type : key-value
+    include:
+    attributes:
+      - MinimumPasswordAge
+      - MaximumPasswordAge
+      - MinimumPasswordLength
+      - PasswordComplexity
+      - PasswordHistorySize
+      - ClearTextPassword
+      - RequireLogonToChangePassword
+      - LockoutBadCount
+      - ResetLockoutCount
+      - LockoutDuration
+      - ForceLogoffWhenHourExpire
+      - LSAAnonymousNameLookup 
+      - EnableAdminAccount 
+      - EnableGuestAccount 
+      - NewAdministratorName
+      - NewGuestName
+  Kerberos Policy:
+    type : key-value
+    include:
+    attributes:
+    - MaxTicketAge
+    - MaxRenewAge
+    - MaxServiceAge
+    - MaxClockSkew
+    - TicketValidateClient
+  System Log:
+    type : key-value
+    include:
+    attributes:
+    - MaximumLogSize
+    - AuditLogRetentionPeriod
+    - RetentionDays
+    - RestrictGuestAccess
+  Security Log:
+    type : key-value
+    include:
+    attributes:
+    - MaximumLogSize
+    - AuditLogRetentionPeriod
+    - RetentionDays
+    - RestrictGuestAccess
+  Application Log:
+    type : key-value
+    include:
+    attributes:
+    - MaximumLogSize
+    - AuditLogRetentionPeriod
+    - RetentionDays
+    - RestrictGuestAccess
+  Event Audit:
+    type : key-value
+    include:
+    attributes:
+    - AuditSystemEvents
+    - AuditLogonEvents
+    - AuditPrivilegeUse
+    - AuditPolicyChange
+    - AuditAccountManage
+    - AuditProcessTracking
+    - AuditDSAccess
+    - AuditObjectAccess
+    - AuditAccountLogon
+  Registry Values:
+    type : key-value
+    include:
+    attributes:
+      - Hive
+      - Type
+      - Data
+  Privilege Rights:
+    type : key-value
+    include:
+    attributes:
+    - SeNetworkLogonRight
+    - SeTcbPrivilege
+    - SeMachineAccountPrivilege
+    - SeIncreaseQuotaPrivilege
+    - SeRemoteInteractiveLogonRight
+    - SeBackupPrivilege
+    - SeChangeNotifyPrivilege
+    - SeCreatePagefilePrivilege
+    - SeSystemtimePrivilege
+    - SeCreateTokenPrivilege
+    - SeCreateGlobalPrivilege
+    - SeCreatePermanentPrivilege
+    - SeDebugPrivilege
+    - SeDenyNetworkLogonRight
+    - SeDenyBatchLogonRight
+    - SeDenyServiceLogonRight
+    - SeDenyInteractiveLogonRight
+    - SeDenyRemoteInteractiveLogonRight
+    - SeEnableDelegationPrivilege
+    - SeRemoteShutdownPrivilege
+    - SeAuditPrivilege
+    - SeImpersonatePrivilege
+    - SeIncreaseBasePriorityPrivilege
+    - SeLoadDriverPrivilege
+    - SeLockMemoryPrivilege
+    - SeBatchLogonRight
+    - SeServiceLogonRight
+    - SeInteractiveLogonRight
+    - SeSecurityPrivilege
+    - SeSystemEnvironmentPrivilege
+    - SeManageVolumePrivilege
+    - SeProfileSingleProcessPrivilege
+    - SeSystemProfilePrivilege
+    - SeUndockPrivilege
+    - SeAssignPrimaryTokenPrivilege
+    - SeRestorePrivilege
+    - SeShutdownPrivilege
+    - SeSyncAgentPrivilege
+    - SeTakeOwnershipPrivilege
+    - SeTrustedCredManAccessPrivilege
+    - SeTimeZonePrivilege
+    - SeCreateSymbolicLinkPrivilege
+    - SeIncreaseWorkingSetPrivilege
+    - SeRelabelPrivilege
+  Registry Keys:
+    type : comma-separated
+    include:
+    attributes:
+      - PermPropagationMode
+      - AclString
+  Service General Setting:
+    type : comma-separated
+    include:
+    attributes:
+      - AclString
+      - StartupMode
+  File Security:
+    type : comma-separated
+    include:
+    attributes:
+      - PermPropagationMode
+      - AclString
+  Group Membership:
+    type : key-value
+    include:
+    attributes:
+      - Members
+      - Memberof

--- a/gpohound/parsers/aas_files.py
+++ b/gpohound/parsers/aas_files.py
@@ -1,0 +1,87 @@
+import struct
+import logging
+from io import BytesIO
+from gpohound.utils.utils import load_yaml_config
+
+
+class AASParser:
+    """Parse .aas files"""
+
+    DATA_TYPE_NULL = 0x0000
+    DATA_TYPE_INT32 = 0x4000
+    DATA_TYPE_NULL_ARG = 0x8000
+    DATA_TYPE_EXTENDED = 0xC000
+
+    def __init__(self, config="config.gpo_files_structure.aas") -> None:
+        self.config = load_yaml_config(config)
+
+    def parse_args(self, data, file_name):
+        """
+        Parse data as specified in section the 2.2.4 section of the MS-GPSI :
+        - https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-GPSI/%5bMS-GPSI%5d.pdf
+        """
+        dtype = struct.unpack("<H", data.read(2))[0]
+
+        if dtype == AASParser.DATA_TYPE_NULL or dtype == AASParser.DATA_TYPE_NULL_ARG:
+            return None
+        elif dtype == AASParser.DATA_TYPE_INT32:
+            return struct.unpack("<i", data.read(4))[0]
+        elif dtype == AASParser.DATA_TYPE_INT32:
+            return struct.unpack("<i", data.read(4))[0]
+        elif dtype == AASParser.DATA_TYPE_EXTENDED:
+            ext_len = struct.unpack("<I", data.read(4))[0]
+            real_type = (ext_len >> 30) & 0x3
+            length = ext_len & 0x3FFFFFFF
+            if real_type == 0:
+                raw = data.read(length)
+                try:
+                    return raw.decode()
+                except UnicodeDecodeError as e:
+                    logging.debug("Decoding error for aas file %s: %s", file_name, e)
+                    return raw
+            elif real_type == 1 or real_type == 2:
+                return data.read(length)
+        else:
+            length = dtype & 0x3FFF
+            dtype = dtype & 0xC000
+            if dtype == AASParser.DATA_TYPE_NULL:
+                raw = data.read(length)
+                try:
+                    return raw.decode()
+                except UnicodeDecodeError as e:
+                    logging.debug("Decoding error for aas file %s: %s", file_name, e)
+                    return raw
+            else:
+                return data.read(length)
+
+    def parse(self, file_path, file_name):
+        """
+        Parse Application Advertise Script
+        """
+
+        if "include" in self.config["aas"]:
+            records = {}
+
+            with open(file_path, "rb") as f:
+                data = BytesIO(f.read())
+
+            while True:
+                opcode, arg_count = struct.unpack("<BB", data.read(2))
+                args = [self.parse_args(data, file_name) for _ in range(arg_count)]
+                records.setdefault(opcode, []).append(args)
+                if opcode == 3:  # End opcode
+                    break
+
+            if 4 in records and 9 in records:
+                product_info = records.get(4)[0]
+                source_list_publish = records.get(9)[0]
+                raw_output = {
+                    "Product Key": product_info[0],
+                    "Product Name": product_info[1],
+                    "Launch Path": source_list_publish[8],
+                    "Package Name": product_info[2],
+                }
+                output = {key: raw_output[key] for key in self.config["aas"]["attributes"] if key in raw_output}
+                return {file_name: output}
+
+        return None

--- a/gpohound/parsers/inf_files.py
+++ b/gpohound/parsers/inf_files.py
@@ -3,7 +3,7 @@ from gpohound.utils.utils import load_yaml_config
 
 
 class INFParser:
-    """Parse GptTmpl.inf"""
+    """Parse .inf files"""
 
     def __init__(self, config="config.gpo_files_structure.inf") -> None:
 
@@ -29,15 +29,21 @@ class INFParser:
             "11": "REG_QWORD",
         }
 
-    def parse(self, file_path):
+    def parse(self, file_path, file_name):
         """
         Read an INF file and populate the results dictionary with its contents
         """
+
+        file_config = self.config.get(file_name.lower())
+
+        if not file_config:
+            return None
 
         current_section = None
 
         with open(file_path, "r", encoding="utf-16") as f:
             results = {}
+
             for line in f:
                 line = line.strip()
                 # Ignore empty lines or comments
@@ -50,11 +56,24 @@ class INFParser:
                     # Extract the section name
                     current_section = section_match.group(1)
                     if current_section not in results:
-                        results[current_section] = {}
+                        if "include" in file_config.get(current_section, {}):
+                            results[current_section] = {}
                         continue
 
+                # Parse strings list
+                if (
+                    file_config.get(current_section).get("type") == "string-list"
+                    and "include" in file_config[current_section]
+                ):
+                    if results.get(current_section):
+                        idx = len(results.get(current_section)) + 1
+                    else:
+                        idx = 1
+                    entry = {str(idx): line.strip('"')}
+                    results[current_section].update(entry)
+
                 # Parse Key = Value settings
-                if self.config.get(current_section).get("type") == "key-value":
+                if file_config.get(current_section).get("type") == "key-value":
                     key_value_match = line.split("=", 1)
 
                     if len(key_value_match) == 2:
@@ -62,12 +81,12 @@ class INFParser:
                         key = key.strip().strip('"')
                         value = value.strip()
 
-                        if "include" in self.config[current_section]:
+                        if "include" in file_config[current_section]:
 
                             # Privilege Rights
                             if (
                                 current_section == "Privilege Rights"
-                                and key in self.config[current_section]["attributes"]
+                                and key in file_config[current_section]["attributes"]
                             ):
                                 results[current_section][key] = value.split(",")
 
@@ -87,7 +106,7 @@ class INFParser:
                                 else:
                                     continue
 
-                                if membership not in self.config[current_section]["attributes"]:
+                                if membership not in file_config[current_section]["attributes"]:
                                     continue
 
                                 results.setdefault(current_section, {}).setdefault(group_name, {}).update(
@@ -108,16 +127,16 @@ class INFParser:
                                 }
 
                                 entry = {
-                                    key: {attr: entry[attr] for attr in self.config[current_section]["attributes"]}
+                                    key: {attr: entry[attr] for attr in file_config[current_section]["attributes"]}
                                 }
                                 results[current_section].update(entry)
 
                             # Simple Key Value
-                            elif key in self.config[current_section]["attributes"]:
+                            elif key in file_config[current_section]["attributes"]:
                                 results[current_section][key] = value.strip('"')
 
                 # Parse comma-separated settings
-                if self.config.get(current_section).get("type") == "comma-separated":
+                if file_config.get(current_section).get("type") == "comma-separated":
                     key, value = line.split(",", 1)
                     key = key.strip('"')
                     attr1, attr2 = [items.strip('"') for items in value.split(",", 1)]
@@ -125,15 +144,15 @@ class INFParser:
                     # Registry Keys and File Security
                     if current_section == "Registry Keys" or current_section == "File Security":
                         entry = {"PermPropagationMode": attr1, "AclString": attr2}
-                        entry = {key: {attr: entry[attr] for attr in self.config[current_section]["attributes"]}}
+                        entry = {key: {attr: entry[attr] for attr in file_config[current_section]["attributes"]}}
                         results[current_section].update(entry)
 
                     # Service General Setting
                     elif current_section == "Service General Setting":
                         entry = {"AclString": attr1, "StartupMode": attr2}
-                        entry = {key: {attr: entry[attr] for attr in self.config[current_section]["attributes"]}}
+                        entry = {key: {attr: entry[attr] for attr in file_config[current_section]["attributes"]}}
                         results[current_section].update(entry)
 
         if results:
-            return {"GptTmpl.inf": results}
+            return {file_name + ".inf": results}
         return None

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "config.gpo_files_structure.ini",
         "config.gpo_files_structure.pol",
         "config.gpo_files_structure.xml",
+        "config.gpo_files_structure.aas",
         "gpohound",
         "gpohound.utils",
         "gpohound.parsers",
@@ -30,6 +31,7 @@ setup(
         "config.gpo_files_structure.ini": ["*.yaml"],
         "config.gpo_files_structure.pol": ["*.yaml"],
         "config.gpo_files_structure.xml": ["*.yaml"],
+        "config.gpo_files_structure.aas": ["*.yaml"],
     },
     install_requires=[
         "pyyaml>=6.0.2",


### PR DESCRIPTION
## Support for .aas and cap.inf files

This pull request adds support for : 
- `.aas` (Application Advertise Script) files, as described in the [Microsoft Application Advertise Script specification](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpsi/c16e6619-1037-4f8b-8715-dc8b23a8b847)
- `cap.inf` files used for Central Access Policy, based on the [Microsoft Central Access Policy specification](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gpcap/b5fad3b6-9c74-45b1-92cd-b82f8a50b58d).

### Output example
![2025-06-16_18-30](https://github.com/user-attachments/assets/d58a21db-1efd-46d4-a4d5-e636a420ceae)

